### PR TITLE
대댓글 구현 완료 하였습니다.

### DIFF
--- a/src/main/java/com/example/intermediate/controller/NestedCommentController.java
+++ b/src/main/java/com/example/intermediate/controller/NestedCommentController.java
@@ -5,10 +5,7 @@ import com.example.intermediate.controller.response.ResponseDto;
 import com.example.intermediate.service.NestedCommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -22,5 +19,25 @@ public class NestedCommentController {
     public ResponseDto<?> createNestedComment(@RequestBody CommentRequestDto requestDto, HttpServletRequest request) {
         return nestedCommentService.createNestedComment(requestDto, request);
     }
+
+    @RequestMapping(value = "/api/nestedComment/{id}", method = RequestMethod.GET)
+    public ResponseDto<?> getAllNestedComments(@PathVariable Long id) {
+        return nestedCommentService.getAllNestedCommentByComment(id);
+    }
+
+    @RequestMapping(value = "/api/auth/nestedComment/{id}", method = RequestMethod.PUT)
+    public ResponseDto<?> updateNestedComment(@PathVariable Long id,@RequestBody CommentRequestDto requestDto, HttpServletRequest request) {
+        return nestedCommentService.updateNestedComment(id, requestDto, request);
+    }
+
+    @RequestMapping(value = "/api/auth/nestedComment/{id}", method = RequestMethod.DELETE)
+    public ResponseDto<?> deleteNestedComment(@PathVariable Long id, HttpServletRequest request) {
+        return nestedCommentService.deleteNestedComment(id, request);
+    }
+
+
+
+
+
 
 }

--- a/src/main/java/com/example/intermediate/controller/NestedCommentController.java
+++ b/src/main/java/com/example/intermediate/controller/NestedCommentController.java
@@ -1,0 +1,26 @@
+package com.example.intermediate.controller;
+
+import com.example.intermediate.controller.request.CommentRequestDto;
+import com.example.intermediate.controller.response.ResponseDto;
+import com.example.intermediate.service.NestedCommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Validated
+@RequiredArgsConstructor
+@RestController
+public class NestedCommentController {
+    private final NestedCommentService nestedCommentService;
+
+    @RequestMapping(value = "/api/auth/nestedComment", method = RequestMethod.POST)
+    public ResponseDto<?> createNestedComment(@RequestBody CommentRequestDto requestDto, HttpServletRequest request) {
+        return nestedCommentService.createNestedComment(requestDto, request);
+    }
+
+}

--- a/src/main/java/com/example/intermediate/domain/NestedComment.java
+++ b/src/main/java/com/example/intermediate/domain/NestedComment.java
@@ -1,0 +1,31 @@
+package com.example.intermediate.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class NestedComment extends Timestamped{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @JoinColumn(name = "comment_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Comment comment;
+
+    @Column(nullable = false)
+    private String content;
+}

--- a/src/main/java/com/example/intermediate/domain/NestedComment.java
+++ b/src/main/java/com/example/intermediate/domain/NestedComment.java
@@ -1,5 +1,6 @@
 package com.example.intermediate.domain;
 
+import com.example.intermediate.controller.request.CommentRequestDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,4 +32,11 @@ public class NestedComment extends Timestamped{
 
     @Column(nullable = false)
     private int numberOfLikes;
+
+    public void update(CommentRequestDto commentRequestDto) {
+        this.content = commentRequestDto.getContent();
+    }
+    public boolean validateMember(Member member) {
+        return !this.member.equals(member);
+    }
 }

--- a/src/main/java/com/example/intermediate/domain/NestedComment.java
+++ b/src/main/java/com/example/intermediate/domain/NestedComment.java
@@ -28,4 +28,7 @@ public class NestedComment extends Timestamped{
 
     @Column(nullable = false)
     private String content;
+
+    @Column(nullable = false)
+    private int numberOfLikes;
 }

--- a/src/main/java/com/example/intermediate/repository/NestedCommentRepository.java
+++ b/src/main/java/com/example/intermediate/repository/NestedCommentRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface NestedCommentRepository extends JpaRepository<NestedComment, Long> {
-    List<Comment> findAllByComment(Comment comment);
+    List<NestedComment> findAllByComment(Comment comment);
+
 }

--- a/src/main/java/com/example/intermediate/repository/NestedCommentRepository.java
+++ b/src/main/java/com/example/intermediate/repository/NestedCommentRepository.java
@@ -1,0 +1,11 @@
+package com.example.intermediate.repository;
+
+import com.example.intermediate.domain.Comment;
+import com.example.intermediate.domain.NestedComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NestedCommentRepository extends JpaRepository<NestedComment, Long> {
+    List<Comment> findAllByComment(Comment comment);
+}

--- a/src/main/java/com/example/intermediate/service/NestedCommentService.java
+++ b/src/main/java/com/example/intermediate/service/NestedCommentService.java
@@ -22,7 +22,7 @@ public class NestedCommentService {
     private final TokenProvider tokenProvider;
     private final CommentService commentService;
     @Transactional
-    public ResponseDto<?> createComment(CommentRequestDto requestDto, HttpServletRequest request) {
+    public ResponseDto<?> createNestedComment(CommentRequestDto requestDto, HttpServletRequest request) {
         if (null == request.getHeader("Refresh-Token")) {
             return ResponseDto.fail("MEMBER_NOT_FOUND",
                     "로그인이 필요합니다.");

--- a/src/main/java/com/example/intermediate/service/NestedCommentService.java
+++ b/src/main/java/com/example/intermediate/service/NestedCommentService.java
@@ -1,0 +1,9 @@
+package com.example.intermediate.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NestedCommentService {
+}

--- a/src/main/java/com/example/intermediate/service/NestedCommentService.java
+++ b/src/main/java/com/example/intermediate/service/NestedCommentService.java
@@ -1,9 +1,72 @@
 package com.example.intermediate.service;
 
+import com.example.intermediate.controller.request.CommentRequestDto;
+import com.example.intermediate.controller.response.CommentResponseDto;
+import com.example.intermediate.controller.response.ResponseDto;
+import com.example.intermediate.domain.Comment;
+import com.example.intermediate.domain.Member;
+import com.example.intermediate.domain.NestedComment;
+import com.example.intermediate.jwt.TokenProvider;
+import com.example.intermediate.repository.NestedCommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
 
 @Service
 @RequiredArgsConstructor
 public class NestedCommentService {
+
+    private final NestedCommentRepository nestedCommentRepository;
+    private final TokenProvider tokenProvider;
+    private final CommentService commentService;
+    @Transactional
+    public ResponseDto<?> createComment(CommentRequestDto requestDto, HttpServletRequest request) {
+        if (null == request.getHeader("Refresh-Token")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        if (null == request.getHeader("Authorization")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        Member member = validateMember(request);
+        if (null == member) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+
+        Comment comment = commentService.isPresentComment(requestDto.getPostId());
+        if (null == comment) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 댓글 id 입니다.");
+        }
+
+        NestedComment nestedComment = NestedComment.builder()
+                .member(member)
+                .comment(comment)
+                .content(requestDto.getContent())
+                .numberOfLikes(0)
+                .build();
+        nestedCommentRepository.save(nestedComment);
+        return ResponseDto.success(
+                CommentResponseDto.builder()
+                        .id(comment.getId())
+                        .author(comment.getMember().getNickname())
+                        .content(comment.getContent())
+                        .createdAt(comment.getCreatedAt())
+                        .modifiedAt(comment.getModifiedAt())
+                        .build()
+        );
+    }
+
+    @Transactional
+    public Member validateMember(HttpServletRequest request) {
+        if (!tokenProvider.validateToken(request.getHeader("Refresh-Token"))) {
+            return null;
+        }
+        return tokenProvider.getMemberFromAuthentication();
+    }
 }
+


### PR DESCRIPTION
#2 

# 만든 클래스

- `NestedCommentController`
- `NestedCommentRepository`
- `NestedCommentService`
- `NestedComment`

# 구현 된 기능

- 대댓글 전체 조회
- 대댓글 작성
- 대댓글 수정
- 대댓글 삭제

# API
|기능|URL|메소드|
|------|---|---|
|대댓글 작성|"/api/auth/nestedComment"|POST|
|대댓글 전체 조회|"/api/nestedComment/{id}"|GET|
|대댓글 수정|"/api/auth/nestedComment/{id}"|PUT|
|대댓글 삭제|"/api/auth/nestedComment/{id}"|DELETE|

# 참고 사항
- 대댓글에 엔티티에 좋아요는 `private int numberOfLikes;` 로 설정하였다.
- dto는 댓글 dto를 사용 하였다. 서로 유사하기 때문에 대댓글 dto를 딱히 만들 필요가 없었다.
    - 하지만 나중에 `CommentRequestDto` 에 postId 변수는 수정 할 필요가 있어 보인다.